### PR TITLE
Added module removal

### DIFF
--- a/projs/shadow/shadow-engine/core/inc/core/Module.h
+++ b/projs/shadow/shadow-engine/core/inc/core/Module.h
@@ -1,5 +1,4 @@
-#ifndef UMBRA_MODULE_H
-#define UMBRA_MODULE_H
+#pragma once
 
 #include "SHObject.h"
 #include "SDL_events.h"
@@ -73,6 +72,5 @@ namespace ShadowEngine {
         virtual VkExtent2D GetRenderExtent() = 0;
     };
 
-} // ShadowEngine
+}
 
-#endif //UMBRA_MODULE_H

--- a/projs/shadow/shadow-engine/core/src/core/ModuleManager.cpp
+++ b/projs/shadow/shadow-engine/core/src/core/ModuleManager.cpp
@@ -50,7 +50,8 @@ void ShadowEngine::ModuleManager::Init()
 {
     for (auto& module : modules)
     {
-        module.module->Init();
+        if(!module.disabled)
+            module.module->Init();
     }
 
     this->Finalise();

--- a/projs/shadow/shadow-engine/shadow-renderer/src/vulkan/VulkanModule.cpp
+++ b/projs/shadow/shadow-engine/shadow-renderer/src/vulkan/VulkanModule.cpp
@@ -85,7 +85,8 @@ void VulkanModule::PreInit() {
 
     ShadowEngine::ModuleManager &moduleManager = shApp.GetModuleManager();
 
-    auto sdl2module = moduleManager.GetModuleByType<ShadowEngine::SDL2Module>();
+    //TODO:: well we should be sure about this... There is a chance SDL might want to quit..
+    auto sdl2module = moduleManager.GetModule<ShadowEngine::SDL2Module>().lock();
 
     CATCH(initVulkan(sdl2module->_window->sdlWindowPtr);)
 

--- a/projs/test-game/inc/TestModule.h
+++ b/projs/test-game/inc/TestModule.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "core/Module.h"
+#include "core/ModuleManager.h"
+#include "spdlog/spdlog.h"
+
+class TestModule : public ShadowEngine::Module {
+SHObject_Base(TestModule)
+
+public:
+    ~TestModule() override = default;
+
+    void PreInit() override {
+        spdlog::info("{0} PreInit", this->GetName());
+    }
+
+    void Init() override {
+        auto self = ShadowEngine::ModuleManager::instance->GetModule<TestModule>();
+        ShadowEngine::ModuleManager::instance->RemoveModule(self);
+
+        spdlog::info("{0} Init", this->GetName());
+    }
+
+    void Update(int frame) override {
+        spdlog::info("{0} Update", this->GetName());
+    }
+
+    void Recreate() override {
+
+    }
+
+    void PreRender() override {
+
+    }
+
+    void Render(VkCommandBuffer &commands, int frame) override {
+
+    }
+
+    void LateRender(VkCommandBuffer &commands, int frame) override {
+
+    }
+
+    void OverlayRender() override {
+
+    }
+
+    void AfterFrameEnd() override {
+
+    }
+
+    void Destroy() override {
+
+    }
+
+    void Event(SDL_Event *e) override {
+
+    }
+
+    std::string GetName() override {
+        return "Test Module";
+    }
+
+};

--- a/projs/test-game/src/GameModule.cpp
+++ b/projs/test-game/src/GameModule.cpp
@@ -23,10 +23,14 @@ std::unique_ptr<vlkx::PushConstant> trans_constant_;
 std::unique_ptr<vlkxtemp::Model> cube_model_;
 float aspectRatio;
 
-void GameModule::PreInit() {  }
+void GameModule::PreInit() {
+    spdlog::info("{0} PreInit", this->GetName());
+}
 
 void GameModule::Init() {
+    spdlog::info("{0} Init", this->GetName());
     spdlog::info("Game Module loading level..");
+
     trans_constant_ = std::make_unique<vlkx::PushConstant>(
             sizeof(Transformation), 2);
 

--- a/projs/test-game/src/TestModule.cpp
+++ b/projs/test-game/src/TestModule.cpp
@@ -1,0 +1,3 @@
+#include "../inc/TestModule.h"
+
+SHObject_Base_Impl(TestModule)

--- a/projs/test-game/src/entry.cpp
+++ b/projs/test-game/src/entry.cpp
@@ -8,7 +8,10 @@
 #include "GameModule.h"
 #include "core/ShadowApplication.h"
 #include "vlkx/vulkan/VulkanModule.h"
+#include "TestModule.h"
 
 extern "C" __declspec(dllexport) void shadow_main(ShadowEngine::ShadowApplication* app) {
+    app->GetModuleManager().PushModule(std::make_shared<TestModule>(), "game");
     app->GetModuleManager().PushModule(std::make_shared<GameModule>(), "game");
+
 }


### PR DESCRIPTION
This PR adds the ability to remove modules during setup. This means that ``RemoveModule`` can be called in ``PreInit`` and ``Init``, this will cause the module to be removed after ``Init`` but before the first ``Update``