### PR TITLE
Remove old ids and dependeny functions

### DIFF
--- a/projs/shadow/shadow-engine/core/inc/core/SDL2Module.h
+++ b/projs/shadow/shadow-engine/core/inc/core/SDL2Module.h
@@ -8,16 +8,16 @@
 namespace ShadowEngine {
 
     class SDL2Module : public Module {
-        SHObject_Base(SDL2Module)
+      SHObject_Base(SDL2Module)
 
-    public:
-        ShadowEngine::ShadowWindow* window;
+      public:
+        ShadowEngine::ShadowWindow *window;
 
-    private:
-    public:
-        SDL2Module() : Module("module:/platform/sdl2") {}
+      private:
+      public:
+        SDL2Module() : Module() {}
 
-    private:
+      private:
 
         void Init() override;
 
@@ -27,11 +27,11 @@ namespace ShadowEngine {
 
         void Recreate() override;
 
-        void Render(VkCommandBuffer& commands, int frame) override;
+        void Render(VkCommandBuffer &commands, int frame) override;
 
         void OverlayRender() override;
 
-        void LateRender(VkCommandBuffer& commands, int frame) override;
+        void LateRender(VkCommandBuffer &commands, int frame) override;
 
         std::string GetName() override;
 
@@ -41,7 +41,7 @@ namespace ShadowEngine {
 
         void Destroy() override;
 
-        void Event(SDL_Event* e) override;
+        void Event(SDL_Event *e) override;
     };
 
 }

--- a/projs/shadow/shadow-engine/core/inc/debug/DebugModule.h
+++ b/projs/shadow/shadow-engine/core/inc/debug/DebugModule.h
@@ -8,34 +8,34 @@ namespace ShadowEngine::Debug {
 
     class DebugModule : public Module {
 
-        SHObject_Base(DebugModule)
+      SHObject_Base(DebugModule)
 
         bool active;
 
-    public:
-        DebugModule() : Module("module:/debug/debugger") {}
+      public:
+        DebugModule() : Module() {}
 
-        void Render(VkCommandBuffer& commands, int frame) override {};
+        void Render(VkCommandBuffer &commands, int frame) override {};
 
-        void PreInit() override {  };
+        void PreInit() override {};
 
-        void Init() override  {  };
+        void Init() override {};
 
         void Recreate() override {};
 
         void OverlayRender() override;
 
-        void Update(int frame) override {  };
+        void Update(int frame) override {};
 
-        void LateRender(VkCommandBuffer& commands, int frame) override {  };
+        void LateRender(VkCommandBuffer &commands, int frame) override {};
 
-        void AfterFrameEnd() override {  };
+        void AfterFrameEnd() override {};
 
-        void PreRender() override { };
+        void PreRender() override {};
 
         void Destroy() override {};
 
-        void Event(SDL_Event* e) override {};
+        void Event(SDL_Event *e) override {};
     };
 
 }

--- a/projs/shadow/shadow-engine/core/src/core/Module.cpp
+++ b/projs/shadow/shadow-engine/core/src/core/Module.cpp
@@ -7,8 +7,4 @@
 namespace ShadowEngine {
 
     SHObject_Base_Impl(Module)
-
-    Module::Module(const std::string &id) : id(id) {}
-
-    RendererModule::RendererModule(const std::string &id) : Module(id) {}
 } // ShadowEngine

--- a/projs/shadow/shadow-engine/shadow-renderer/inc/vlkx/vulkan/VulkanModule.h
+++ b/projs/shadow/shadow-engine/shadow-renderer/inc/vlkx/vulkan/VulkanModule.h
@@ -13,20 +13,17 @@
 namespace vlkx { class ScreenRenderPassManager; }
 
 class VulkanModule : public ShadowEngine::RendererModule {
-    SHObject_Base(VulkanModule);
-public:
+  SHObject_Base(VulkanModule);
+  public:
 
-    VulkanModule(): RendererModule("module:/renderer/vulkan") { instance = this; }
-	~VulkanModule() override;
+    VulkanModule() : RendererModule() { instance = this; }
 
-    std::vector<std::string> GetDependencies() override {
-        return {"module:/platform/sdl2"};
-    }
+    ~VulkanModule() override;
 
 #ifdef _DEBUG
-	static const bool validationRequired = true;
+    static const bool validationRequired = true;
 #else
-	static const bool validationRequired = false;
+    static const bool validationRequired = false;
 #endif
 
     void PreInit() override;
@@ -39,65 +36,72 @@ public:
 
     void PreRender() override;
 
-    void Render(VkCommandBuffer& commands, int frame) override;
+    void Render(VkCommandBuffer &commands, int frame) override;
 
     void OverlayRender() override;
 
-    void LateRender(VkCommandBuffer& commands, int frame) override;
+    void LateRender(VkCommandBuffer &commands, int frame) override;
 
     void AfterFrameEnd() override;
 
     void Destroy() override;
 
-    void Event(SDL_Event* e) override;
+    void Event(SDL_Event *e) override;
 
-    void BeginRenderPass(const std::unique_ptr<vlkx::RenderCommand>& commands) override;
+    void BeginRenderPass(const std::unique_ptr<vlkx::RenderCommand> &commands) override;
 
     void EnableEditor() override;
 
     VkExtent2D GetRenderExtent() override;
 
-	// VulkanModule is a singleton class.
-	static VulkanModule* instance;
-	static VulkanModule* getInstance();
+    // VulkanModule is a singleton class.
+    static VulkanModule *instance;
 
-	// Initialize all Vulkan context and prepare validations in debug mode.
-	void initVulkan(SDL_Window* window);
-	void createAppAndVulkanInstance(bool enableValidation, ValidationAndExtension* validations);
+    static VulkanModule *getInstance();
 
-	// Start and end a frame render.
-	void startDraw();
-	void endDraw();
+    // Initialize all Vulkan context and prepare validations in debug mode.
+    void initVulkan(SDL_Window *window);
 
-	// Cleanup after the application has closed.
-	void cleanup();
+    void createAppAndVulkanInstance(bool enableValidation, ValidationAndExtension *validations);
 
-	VkInstance getVulkan() { return vulkan; }
-	VulkanDevice* getDevice() { return device; }
-	SwapChain* getSwapchain() { return swapchain; }
-	VmaAllocator getAllocator() { return allocator; }
-    SDL_Window* getWind() { return wnd; }
-    const std::unique_ptr<vlkx::ScreenRenderPassManager>& getRenderPass();
+    // Start and end a frame render.
+    void startDraw();
 
+    void endDraw();
 
-private:
+    // Cleanup after the application has closed.
+    void cleanup();
+
+    VkInstance getVulkan() { return vulkan; }
+
+    VulkanDevice *getDevice() { return device; }
+
+    SwapChain *getSwapchain() { return swapchain; }
+
+    VmaAllocator getAllocator() { return allocator; }
+
+    SDL_Window *getWind() { return wnd; }
+
+    const std::unique_ptr<vlkx::ScreenRenderPassManager> &getRenderPass();
+
+  private:
     bool editorEnabled = false;
     std::vector<VkDescriptorSet> editorRenderPlanes;
     std::vector<std::unique_ptr<vlkx::Image>> editorContentFrames;
 
     // The SDL Window contains the size of the drawable area.
-    SDL_Window* wnd;
-	// To handle the validation of Vulkan API usage
-	ValidationAndExtension* validators{};
-	// To manage interaction with the hardware
-	VulkanDevice* device{};
-	// To handle the framebuffers
-	SwapChain* swapchain{};
-	// To handle automatic management of memory.
-	VmaAllocator allocator{};
-	// To manage the Vulkan context that was passed to us by the API
-	VkInstance vulkan{};
-	// To manage the canvas that was given to us by GLFW
-	VkSurfaceKHR surface{};
+    SDL_Window *wnd;
+    // To handle the validation of Vulkan API usage
+    ValidationAndExtension *validators{};
+    // To manage interaction with the hardware
+    VulkanDevice *device{};
+    // To handle the framebuffers
+    SwapChain *swapchain{};
+    // To handle automatic management of memory.
+    VmaAllocator allocator{};
+    // To manage the Vulkan context that was passed to us by the API
+    VkInstance vulkan{};
+    // To manage the canvas that was given to us by GLFW
+    VkSurfaceKHR surface{};
 
 };

--- a/projs/test-game/inc/GameModule.h
+++ b/projs/test-game/inc/GameModule.h
@@ -5,11 +5,11 @@
 
 class GameModule : public ShadowEngine::Module {
 
-    SHObject_Base(GameModule)
+  SHObject_Base(GameModule)
 
     std::string test = "asdasd";
-public:
-    GameModule() : Module("module:/test-game/GameModule") {}
+  public:
+    GameModule() : Module() {}
 
     void PreInit() override;
 
@@ -23,14 +23,14 @@ public:
 
     void OverlayRender() override;
 
-    void Render(VkCommandBuffer& commands, int frame) override;
+    void Render(VkCommandBuffer &commands, int frame) override;
 
-    void LateRender(VkCommandBuffer& commands, int frame) override;
+    void LateRender(VkCommandBuffer &commands, int frame) override;
 
     void AfterFrameEnd() override;
 
     void Destroy() override;
 
-    void Event(SDL_Event*) override;
+    void Event(SDL_Event *) override;
 
 };


### PR DESCRIPTION
The last PR added the more complex module system but the removal of some of the old functions and constructors didn't happen.