### PR TITLE
Fix compile errors (gcc complains)

### DIFF
--- a/projs/shadow/shadow-engine/core/src/core/module-manager-v2.cpp
+++ b/projs/shadow/shadow-engine/core/src/core/module-manager-v2.cpp
@@ -2,6 +2,7 @@
 
 #include "core/module-manager-v2.h"
 #include <ranges>
+#include <algorithm>
 
 namespace ShadowEngine {
 

--- a/projs/shadow/shadow-engine/shadow-entity/inc/NodeContainer.h
+++ b/projs/shadow/shadow-engine/shadow-entity/inc/NodeContainer.h
@@ -193,7 +193,7 @@ namespace ShadowEngine::Entities {
             NodeContainer<Type> *container;
             int chunk_index;
 
-            MemoryChunk::Iterator element;
+            typename MemoryChunk::Iterator element;
           public:
             Iterator(NodeContainer<Type> *cont, int c_index) :
                 container(cont),
@@ -265,7 +265,7 @@ namespace ShadowEngine::Entities {
 
             int GetChunkIndex() const { return chunk_index; }
 
-            MemoryChunk::Iterator GetElement() const { return element; }
+            typename MemoryChunk::Iterator GetElement() const { return element; }
 
         };
 


### PR DESCRIPTION
std::range::any_of is in \<algorithm\>, not \<ranges\>.
typename must be explicitly specified, else:
> D:/Coding/umbra/projs/shadow/shadow-engine/shadow-entity/inc/NodeContainer.h:196:13: error: missing 'typename' prior to dependent type name 'MemoryChunk::Iterator'
            MemoryChunk::Iterator element;
            ^~~~~~~~~~~~~~~~~~~~~
            typename 