### PR TITLE
Fix cmake build on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,8 @@
 cmake_minimum_required(VERSION 3.24)
 
-set_property(GLOBAL PROPERTY GLOBAL_DEPENDS_DEBUG_MODE 1)
+include(FetchContent)
 
-#if (MSVC)
-#    add_compile_options(-Zc:externC /permissive- /Zc:__cplusplus /Zc:inline /Zc:preprocessor /Zc:lambda /Zc:templateScope)
-#endif ()
-if (GNU)
-    #add_compile_options(-fpermissive)
-endif ()
+set_property(GLOBAL PROPERTY GLOBAL_DEPENDS_DEBUG_MODE 0)
 
 # Import some find files
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")

--- a/projs/shadow/CMakeLists.txt
+++ b/projs/shadow/CMakeLists.txt
@@ -8,7 +8,7 @@ add_subdirectory(extern/spdlog)
 add_subdirectory(extern/dylib)
 add_subdirectory(extern/vulkan_memory_allocator)
 add_subdirectory(extern/catch2)
-add_subdirectory(extern/SDL2)
+include(extern/SDL2/CMakeLists.txt)
 
 
 # Core engine

--- a/projs/shadow/extern/SDL2/CMakeLists.txt
+++ b/projs/shadow/extern/SDL2/CMakeLists.txt
@@ -5,10 +5,10 @@ if (WIN32)
     # Fetch SDL for the runtime
     FetchContent_Declare(
             SDL2
-            URL https://www.libsdl.org/release/SDL2-devel-2.26.0-VC.zip
+            URL https://www.libsdl.org/release/SDL2-devel-2.30.2-VC.zip
     )
     FetchContent_MakeAvailable(SDL2)
     set(SDL2_DIR ${sdl2_SOURCE_DIR})
-    list(PREPEND CMAKE_PREFIX_PATH "${sdl2_SOURCE_DIR}/cmake")
+    list(APPEND CMAKE_PREFIX_PATH "${sdl2_SOURCE_DIR}/cmake")
 
 endif ()

--- a/projs/shadow/shadow-engine/CMakeLists.txt
+++ b/projs/shadow/shadow-engine/CMakeLists.txt
@@ -1,7 +1,4 @@
-#find_package(Vulkan REQUIRED)
-#find_package(DirectXMath REQUIRED)
 find_package(SDL2 CONFIG REQUIRED)
-#find_package(glm REQUIRED)
 find_package(ImGui REQUIRED)
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
Fixed the CMake build on windows. The add_subdirectory was making a new scope so the changes to config prefix path was not propagated up to the parent. Changed it to include to keep the same scope.